### PR TITLE
Fixed broken link in the readme file pointing to online documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There are two versions of the DevExpress MVVM Framework:
 1. The version that is included to the DevExpress WPF/Silverlight component suite.
 2. The free version that is very similar to the first one. The only difference is that it does not contain some capabilities that are only needed when the framework is used with DevExpress components.
 
-Although DevExpress provides documentation for the first version only, you can use this documentation even if you use the free version. The documentation is available by the following link: https://documentation.devexpress.dev/#WPF/CustomDocument15112
+Although DevExpress provides documentation for the first version only, you can use this documentation even if you use the free version. The documentation is available by the following link: https://documentation.devexpress.com/#WPF/CustomDocument15112
 
 At the DevExpress site, you can find several training blog posts: https://community.devexpress.com/blogs/wpf/archive/2013/08/29/getting-started-with-devexpress-mvvm-framework-commands-and-view-models.aspx
 


### PR DESCRIPTION
Hi there.  I noticed the link to the documentation in the readme file was broken.  I fixed it in this pull request.
